### PR TITLE
Custom commands patch

### DIFF
--- a/commands/commands.js
+++ b/commands/commands.js
@@ -197,17 +197,16 @@ function comObjBuilder(){
     contents = fs.readFileSync("./commands/custom.json");
     jsonObj = JSON.parse(contents);
     names = _.map(jsonObj.commands, "name");
-// iterate names and messages by index[i]. 
-for(var i=0;i < names.length;i++){
-    name = names[i];
-    //build array of custom commands
-    customCom[name.replace("!","")] = clearance.viewer(
+        // iterate names and messages by index[i]. 
+        for(var i=0;i < names.length;i++){
+            name = names[i];
+            //build array of custom commands
+            customCom[name.replace("!","")] = clearance.viewer(
             // function in addMessage parameter fetches message of custom command when clearance.broadcaster() is called.
-        function(channel,userstate,message){queue.addMessage(channel,getM(message));});
- }
+            function(channel,userstate,message){queue.addMessage(channel,getM(message));});
+        }
     _.merge(commands, customCom);
-    console.log(commands);
-}
+ }
  
  // fetches the message for a custom command
 function getM(command)
@@ -226,9 +225,7 @@ function mergeCommands()
     Object.assign(commands, raid.commands);
     // merge custom commands to commands 
     _.merge(commands, customCom);
- console.log();
 }
-
 
 // make magic happen
 comObjBuilder();

--- a/commands/commands.js
+++ b/commands/commands.js
@@ -66,7 +66,8 @@ const reply = (text) => clearance.viewer((channel, userstate) => {
  * broadcaster commands         description                                  file
  * ------------------------     -------------------------------------------- -----------------------
  * !raidstart                   Broadcaster prepares to raid                 /commands/raids.js
- * !commands add !command msg   adds custom command named [!command] with message [msg]
+ * !commands add|edit|delete    add|edit|delete a custom command             /commands/custom.js
+ * !testCommand                 For dev testing
  *
  */
 

--- a/commands/custom.js
+++ b/commands/custom.js
@@ -1,5 +1,6 @@
 var jsonObj = require("./custom.json");
 const fs = require("fs");
+const _ = require("lodash");
 
 // message is passed from "commands" in commands.js
 // sends the command and message to the
@@ -36,7 +37,13 @@ function addCommand(command,message){
         
 function editCommand(command, message){};
 
-function deleteCommand(command, message){};
+function deleteCommand(command, message){
+    
+    var index = _.findIndex(jsonObj.commands, function(c) { return c.name == command; });
+    jsonObj.commands.splice(index, 1);
+    console.log(jsonObj);
+    fs.writeFileSync("./commands/custom.json", JSON.stringify(jsonObj), (err) => {if (err){ console.log(err);}});
+};
 
 module.exports.comHandler = comHandler;
 

--- a/commands/custom.js
+++ b/commands/custom.js
@@ -1,3 +1,10 @@
+// TODO 
+// - error handling
+// - refactor to access fs as little as possible.
+// - user feedback
+
+
+
 var jsonObj = require("./custom.json");
 const fs = require("fs");
 const _ = require("lodash");
@@ -32,16 +39,27 @@ function addCommand(command,message){
     // command and message are passed from comHandler.
     // push new command and its message to the json object
     jsonObj.commands.push({name:command,message:message});
+    // overwrite file with jsonObj
     fs.writeFileSync("./commands/custom.json", JSON.stringify(jsonObj), (err) => {if (err){ console.log(err);}});
 };
         
-function editCommand(command, message){};
-
-function deleteCommand(command, message){
-    
+function editCommand(command, message){
+    console.log("editCommand was called");
+    //find index of command name
     var index = _.findIndex(jsonObj.commands, function(c) { return c.name == command; });
+    // remove command object at index
+    jsonObj.commands[index].message = message;
+    fs.writeFileSync("./commands/custom.json", JSON.stringify(jsonObj), (err) => {if (err){ console.log(err);}});
+    
+};
+
+// Deletes custom command
+function deleteCommand(command, message){
+    // command and message are passed from comHandler.
+    // find index of command name
+    var index = _.findIndex(jsonObj.commands, function(c) { return c.name == command; });
+    // remove command object at index
     jsonObj.commands.splice(index, 1);
-    console.log(jsonObj);
     fs.writeFileSync("./commands/custom.json", JSON.stringify(jsonObj), (err) => {if (err){ console.log(err);}});
 };
 

--- a/commands/custom.js
+++ b/commands/custom.js
@@ -1,7 +1,7 @@
 // TODO 
 // - error handling
 // - refactor to access fs as little as possible.
-// - user feedback
+// - update status to user
 
 
 
@@ -44,7 +44,6 @@ function addCommand(command,message){
 };
         
 function editCommand(command, message){
-    console.log("editCommand was called");
     //find index of command name
     var index = _.findIndex(jsonObj.commands, function(c) { return c.name == command; });
     // remove command object at index


### PR DESCRIPTION
* Custom Commands can now be created
  *  Currently set to broadcaster only
  *  !commands add !commandName MESSAGE
  *  !commands edit !commandName NEWMESSAGE
  *  !commands delete !commandName
  *  created commands are stored in commands/custom.json

* package.json - added script parameter for using nodejs in IDEs

* added broadcaster only !testcommand for development testing

* moved
 ``` 
Object.assign(commands, raid.commands);
_.merge(commands, customCom);
```
to
 ```  mergeCommands();  ```

 in commands.js

* Updated Beastie's command chart in commands.js